### PR TITLE
possible-paths-hotfix

### DIFF
--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -51,6 +51,9 @@ export class TopbarComponent implements OnInit, DoCheck {
 
   // Calculate the possible number of paths
   calculatePossiblePaths(currPointAmount:number): string{
+    if (currPointAmount < 3) {
+      return "N/A"
+    }
     // Format properly depending on number size
     let possiblePaths = this.factorial(currPointAmount - 1) / 2
     if (possiblePaths < 100000000) {


### PR DESCRIPTION
Ensure possible paths is only displayed if there is a sufficient number of points selected (>= 3)
Also somehow fixed bug where clear button wasn't resetting the number of possible paths