### PR TITLE
Nearest Insertion Algorithm Implemented

### DIFF
--- a/src/app/grid/path/path.component.ts
+++ b/src/app/grid/path/path.component.ts
@@ -14,7 +14,7 @@ export class PathComponent implements OnInit, DoCheck {
   allTypeChangetick: boolean = false;
   prevAllTypeChangetick: boolean = false;
 
-  type: number = 0; //setting colour: 0 - light grey; 1 - solid black; 2 - yellow?
+  type: number = 2; //setting colour: 0 - light grey; 1 - solid black; 2 - yellow?
   pointSpacing: number = 34;
 
   pathWidth: number = 50; // Div width

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -62,6 +62,7 @@ export class TopbarComponent implements OnInit, DoCheck {
   // Distance control
   currentPathDistance:number = 0;         // Current path distance
   minPathDistance:number = 0;             // Minimum path distance
+  distanceMatrix:number[][] = [];         // Matrix of distances between points
 
   // Algorithm Select
   algorithmControl =  new FormControl();  // Initialise form control for algorithm selector
@@ -507,6 +508,10 @@ export class TopbarComponent implements OnInit, DoCheck {
     for (let i=0; i<this.selectedPoints.length-1; i++) {
       partOfCycle.push(false);
     }
+    // Calculate distances matrix
+    this.calculateDistanceMatrix()
+    console.log(this.distanceMatrix);
+
     // Declare required variables for algorithm
     let nextPointToAdd:any;
     let distanceFromPoint:number;
@@ -514,37 +519,15 @@ export class TopbarComponent implements OnInit, DoCheck {
     let minDistanceFromPointIndex:number;
     let minDistanceAllPoints:number;
     let minDistanceAllPointsIndex:number;
+    let edges:number[];
 
     // Start of main algorithm logic
-    for (let _=0; _<this.selectedPoints.length-1; _++) {
+    for (let _=0; _<this.selectedPoints.length; _++) {
       minDistanceAllPoints = Infinity;  // Reset distance from all points
       // Base case with the first point and drawing first path
-      if (this.data.currPaths.length === 0) {
-        minDistanceFromPoint = Infinity;
-        // Find minimum distance of all remaining points'
-        for (let i=0; i<this.selectedPoints.length; i++) {
-          // Only check if point is not already part of cycle
-          if (partOfCycle[i] === false) {
-            distanceFromPoint = this.distanceBetweenPoints(this.selectedPoints[0], this.selectedPoints[i])
-            if (distanceFromPoint < minDistanceFromPoint) {
-              minDistanceFromPoint = distanceFromPoint;
-              minDistanceFromPointIndex = i;
-            }
-          }
-        }  // Minimum distance from initial point found
-        partOfCycle[minDistanceFromPointIndex] = true;      // Mark this second point as visited
-        await this.sleep(this.runSpeed);                    // Making use of async-await
-        // Set the first path
-        this.createPath({A:{x:this.selectedPoints[0].x, y:this.selectedPoints[0].y},
-                         B:{x:this.selectedPoints[minDistanceFromPointIndex].x, y:this.selectedPoints[minDistanceFromPointIndex].y}});
-        this.data.setIndividualPathType(this.data.currPaths[0], 2);  // Set the path to yellow
-      }  // End of first point base case
-      // Iterative case with path selection
-      else {
-        console.log("Out of the base case!")
-      }
-    }
-  }
+
+    }    // End of main algorithm for loop
+  }      // End of nearest insertion algorithm function
 
   // Furthest Insertion
   async furtherInsertion():Promise<void> {
@@ -580,6 +563,28 @@ export class TopbarComponent implements OnInit, DoCheck {
   shuffleSelectedPoints():void {
     this.data.shuffleSelectedPoints()
     // console.log(this.selectedPoints)
+  }
+
+  // Calculates the matrix of distances between selected points
+  calculateDistanceMatrix():void {
+    let row:number[];
+    let distance:number;
+    for (let i=0; i<this.selectedPoints.length; i++) {
+      row = [];
+      for (let j=0; j<this.selectedPoints.length; j++) {
+        if (i===j) {
+          row.push(0)
+          console.log("pushed")
+        }
+        else {
+          distance = this.distanceBetweenPoints(this.selectedPoints[i], this.selectedPoints[j])
+          row.push(distance)
+          console.log("pushed2")
+        }
+      }
+      console.log(row);
+      this.distanceMatrix.push(row);
+    }
   }
 
   //--------------------------------------------------------------------------------------------------------------------

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -513,21 +513,45 @@ export class TopbarComponent implements OnInit, DoCheck {
     console.log(this.distanceMatrix);
 
     // Declare required variables for algorithm
-    let nextPointToAdd:any;
-    let distanceFromPoint:number;
     let minDistanceFromPoint:number;
     let minDistanceFromPointIndex:number;
     let minDistanceAllPoints:number;
     let minDistanceAllPointsIndex:number;
-    let edges:number[];
 
-    // Start of main algorithm logic
-    for (let _=0; _<this.selectedPoints.length; _++) {
-      minDistanceAllPoints = Infinity;  // Reset distance from all points
-      // Base case with the first point and drawing first path
+    // Start of main algorithm logic, need to draw n-1 paths
+    for (let _=0; _<this.selectedPoints.length-1; _++) {
+      minDistanceAllPoints = Infinity;  // Reset minimum distance from all points
+      // Find minimum distance to unvisited point from a visited point
+      for (let i=0; i<this.selectedPoints.length; i++) {
+        minDistanceFromPoint = Infinity // Reset minimum distance from curent point
+        if (partOfCycle[i]) {  // Only check visited nodes
+          for (let j=0; j<this.selectedPoints.length; j++) {
+            if (!partOfCycle[j]) {  // Only compare with unvisited nodes
+              if (this.distanceMatrix[i][j] < minDistanceFromPoint) {  // Closer node found
+                minDistanceFromPoint = this.distanceMatrix[i][j];      // Update currently closest node
+                minDistanceFromPointIndex = j;
+              }
+            }
+          }  // End of comparing all unvisited points with visited points
+          if (minDistanceFromPoint < minDistanceAllPoints) {
+            minDistanceAllPoints = minDistanceFromPoint;               // Update closest node from a point
+            minDistanceAllPointsIndex = minDistanceFromPointIndex;
+          }
+        }
+      }      // End of iterating through all visited points, closest node and index should be found
+      partOfCycle[minDistanceAllPointsIndex] = true;  // Set that node to be part of the cycle
+      console.log(minDistanceAllPointsIndex);
+      // Find insertion that will minimise the addition of distance
+      if (this.data.currPaths.length === 0) {  // Base case with the first point
+        this.createPath({A:{x:this.selectedPoints[0].x, y:this.selectedPoints[0].y},
+                         B:{x:this.selectedPoints[minDistanceAllPointsIndex].x,
+                            y:this.selectedPoints[minDistanceAllPointsIndex].y}})
+      }
+      else {  // Main case with paths to check and remove
 
-    }    // End of main algorithm for loop
-  }      // End of nearest insertion algorithm function
+      }
+    }        // End of main algorithm for loop
+  }          // End of entire nearest insertion algorithm function
 
   // Furthest Insertion
   async furtherInsertion():Promise<void> {
@@ -574,15 +598,12 @@ export class TopbarComponent implements OnInit, DoCheck {
       for (let j=0; j<this.selectedPoints.length; j++) {
         if (i===j) {
           row.push(0)
-          console.log("pushed")
         }
         else {
           distance = this.distanceBetweenPoints(this.selectedPoints[i], this.selectedPoints[j])
           row.push(distance)
-          console.log("pushed2")
         }
       }
-      console.log(row);
       this.distanceMatrix.push(row);
     }
   }

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -503,12 +503,47 @@ export class TopbarComponent implements OnInit, DoCheck {
   async nearestInsertion():Promise<void> {
     console.log("Starting Nearest Insertion!")
     // Initialise array of points included/excluded from cycle
-    let partOfCycle:boolean[] = [];
-    for (let i=0; i<this.selectedPoints.length; i++) {
+    let partOfCycle:boolean[] = [true];
+    for (let i=0; i<this.selectedPoints.length-1; i++) {
       partOfCycle.push(false);
     }
-    console.log(this.data.currPaths);
-    console.log(this.data.currPaths.length);
+    // Declare required variables for algorithm
+    let nextPointToAdd:any;
+    let distanceFromPoint:number;
+    let minDistanceFromPoint:number;
+    let minDistanceFromPointIndex:number;
+    let minDistanceAllPoints:number;
+    let minDistanceAllPointsIndex:number;
+
+    // Start of main algorithm logic
+    for (let _=0; _<this.selectedPoints.length-1; _++) {
+      minDistanceAllPoints = Infinity;  // Reset distance from all points
+      // Base case with the first point and drawing first path
+      if (this.data.currPaths.length === 0) {
+        minDistanceFromPoint = Infinity;
+        // Find minimum distance of all remaining points'
+        for (let i=0; i<this.selectedPoints.length; i++) {
+          // Only check if point is not already part of cycle
+          if (partOfCycle[i] === false) {
+            distanceFromPoint = this.distanceBetweenPoints(this.selectedPoints[0], this.selectedPoints[i])
+            if (distanceFromPoint < minDistanceFromPoint) {
+              minDistanceFromPoint = distanceFromPoint;
+              minDistanceFromPointIndex = i;
+            }
+          }
+        }  // Minimum distance from initial point found
+        partOfCycle[minDistanceFromPointIndex] = true;      // Mark this second point as visited
+        await this.sleep(this.runSpeed);                    // Making use of async-await
+        // Set the first path
+        this.createPath({A:{x:this.selectedPoints[0].x, y:this.selectedPoints[0].y},
+                         B:{x:this.selectedPoints[minDistanceFromPointIndex].x, y:this.selectedPoints[minDistanceFromPointIndex].y}});
+        this.data.setIndividualPathType(this.data.currPaths[0], 2);  // Set the path to yellow
+      }  // End of first point base case
+      // Iterative case with path selection
+      else {
+        console.log("Out of the base case!")
+      }
+    }
   }
 
   // Furthest Insertion

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -593,6 +593,16 @@ export class TopbarComponent implements OnInit, DoCheck {
     }  // End of main algorithm for loop
     await this.sleep(this.runSpeed);        // Making use of async-await
     this.createPath(firstPath);             // Add back the first path to finish off
+
+    // Calculate the total path distance
+    let pathsDistance:number = 0;
+
+    for (let i=0; i<this.data.currPaths.length; i++) {
+      pathsDistance += this.calculatePathLength(this.data.currPaths[i]);
+    }
+    this.currentPathDistance = Math.round((pathsDistance + Number.EPSILON) * 100) / 100;
+    this.minPathDistance = this.currentPathDistance;
+
   }  // End of entire nearest insertion algorithm function
 
   // Furthest Insertion

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -521,6 +521,7 @@ export class TopbarComponent implements OnInit, DoCheck {
     let extraDistance:number;
     let minExtraDistance:number;
     let minExtraDistancePath:{A:{x:number, y:number}, B:{x:number, y:number}};
+    let firstPath:{A:{x:number, y:number}, B:{x:number, y:number}};
 
     // Start of main algorithm logic, need to draw n-1 paths
     for (let _=0; _<this.selectedPoints.length-1; _++) {
@@ -551,6 +552,7 @@ export class TopbarComponent implements OnInit, DoCheck {
         this.createPath({A:{x:this.selectedPoints[0].x, y:this.selectedPoints[0].y},
                          B:{x:this.selectedPoints[minDistanceAllPointsIndex].x,
                             y:this.selectedPoints[minDistanceAllPointsIndex].y}})
+        firstPath = this.data.currPaths[0];  // Store the first path for the end
       }
       else {  // Main case with paths to check and insert
         minExtraDistance = Infinity;
@@ -577,6 +579,7 @@ export class TopbarComponent implements OnInit, DoCheck {
                         B:{x:minExtraDistancePath.B.x, y:minExtraDistancePath.B.y}});
       }
     }        // End of main algorithm for loop
+    this.createPath(firstPath);
   }          // End of entire nearest insertion algorithm function
 
   // Furthest Insertion

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -67,7 +67,7 @@ export class TopbarComponent implements OnInit, DoCheck {
   algorithmControl =  new FormControl();  // Initialise form control for algorithm selector
   algorithmsMenu: AlgorithmGroup[] = [
     {
-      name: "Exhaustive Algorithms",
+      name: "Brute Force Algorithms",
       algorithm: [
         {value: "depth-first-search", viewValue: "Depth First Search"},
         {value: "random-search", viewValue: "Random"},
@@ -78,9 +78,10 @@ export class TopbarComponent implements OnInit, DoCheck {
       name: "Heuristic Algorithms",
       algorithm: [
         {value: "nearest-neighbour", viewValue: "Nearest Neighbour"},
-        {value: "arbitrary-insertion", viewValue: "Arbitrary Insertion"},
         {value: "nearest-insertion", viewValue: "Nearest Insertion"},
-        {value: "furthest-insertion", viewValue: "Furthest Insertion"}
+        {value: "furthest-insertion", viewValue: "Furthest Insertion"},
+        {value: "arbitrary-insertion", viewValue: "Arbitrary Insertion"},
+        {value: "convex-hull", viewValue: "Convex Hull"}
       ]
     }
   ]
@@ -272,6 +273,10 @@ export class TopbarComponent implements OnInit, DoCheck {
       case "furthest-insertion":
         await this.furtherInsertion()
         break
+
+      case "convex-hull":
+        await this.convexHull()
+        break
     }
 
     // =================================================================================================================
@@ -306,7 +311,10 @@ export class TopbarComponent implements OnInit, DoCheck {
     }
   }
 
+  //--------------------------------------------------------------------------------------------------------------------
   // Exhaustive algorithms
+
+  // Depth First Search
   async depthFirstSearch():Promise<void> {  // recursive implementation
     console.log("Starting Depth First Search!")
     // Copy of selected points created for safety
@@ -337,7 +345,7 @@ export class TopbarComponent implements OnInit, DoCheck {
     this.minPathDistance = this.currentPathDistance;
   }
 
-  // depthFirstSearch: Recursive asynchronous helper function to go through all possible combinations of points
+  // depthFirstSearch Helper: Recursive asynchronous function to go through all possible combinations of points
   async permutePoints(leftoverPoints:{x:number, y:number}[], pointSequence:{x:number, y:number}[], previousPoint: {x:number, y:number}, sol:{minDist:number, minPath:{x:number, y:number}[]}): Promise<void>{
 
     if (this.abort) { // multiple abort checks to catch recursive calls at various depths and abort
@@ -415,15 +423,20 @@ export class TopbarComponent implements OnInit, DoCheck {
 
   }
 
-  randomSearch():void {
+  // Random Search
+  async randomSearch():Promise<void> {
     console.log("Starting Random Search!")
   }
 
-  branchAndBound():void {
+  // Branch and Bound Algorithm
+  async branchAndBound():Promise<void> {
     console.log("Starting Branch and Bound!")
   }
 
+  //--------------------------------------------------------------------------------------------------------------------
   // Heuristic algorithms
+
+  // Nearest Neighbour
   async nearestNeighbour():Promise<void>{
     console.log("Starting Nearest Neighbour!")
     // Initialise array of visited points (first point will be considered visited)
@@ -486,19 +499,35 @@ export class TopbarComponent implements OnInit, DoCheck {
     this.minPathDistance = this.currentPathDistance;
   }
 
-  arbitraryInsertion():void {
+  // Nearest Insertion
+  async nearestInsertion():Promise<void> {
+    console.log("Starting Nearest Insertion!")
+    // Initialise array of points included/excluded from cycle
+    let partOfCycle:boolean[] = [];
+    for (let i=0; i<this.selectedPoints.length; i++) {
+      partOfCycle.push(false);
+    }
+    console.log(this.data.currPaths);
+    console.log(this.data.currPaths.length);
+  }
+
+  // Furthest Insertion
+  async furtherInsertion():Promise<void> {
+    console.log("Starting Furthest Insertion!")
+  }
+
+  // Arbitrary Insertion
+  async arbitraryInsertion():Promise<void> {
     console.log("Starting Arbitrary Insertion!")
   }
 
-  nearestInsertion():void {
-    console.log("Starting Nearest Insertion!")
+  // Convex Hull
+  async convexHull():Promise<void> {
+    console.log("Starting Convex Hull!")
   }
 
-  furtherInsertion():void {
-    console.log("Starting furthest insertion")
-  }
-
-  // Algorithm helpers
+  //--------------------------------------------------------------------------------------------------------------------
+  // General algorithm helpers
 
   // Calculates distance bewtween 2 points
   distanceBetweenPoints(pointA:{x:number, y:number}, pointB:{x:number, y:number}):number {

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -589,10 +589,6 @@ export class TopbarComponent implements OnInit, DoCheck {
         this.createPath({A:{x:this.selectedPoints[minDistanceAllPointsIndex].x,
                             y:this.selectedPoints[minDistanceAllPointsIndex].y},
                         B:{x:minExtraDistancePath.B.x, y:minExtraDistancePath.B.y}});
-        await this.sleep(0.1);
-        this.data.setIndividualPathType(this.data.currPaths[this.data.currPaths.length-1], 2);
-        await this.sleep(0.1);
-        this.data.setIndividualPathType(this.data.currPaths[this.data.currPaths.length-2], 2);
       }
     }  // End of main algorithm for loop
     await this.sleep(this.runSpeed);        // Making use of async-await

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -484,7 +484,6 @@ export class TopbarComponent implements OnInit, DoCheck {
       // Create the path as yellow
       this.createPath({A:{x:this.selectedPoints[previousIndex].x, y:this.selectedPoints[previousIndex].y},
                        B:{x:this.selectedPoints[currentIndex].x,  y:this.selectedPoints[currentIndex].y}});
-      this.data.setIndividualPathType(this.data.currPaths[this.data.currPaths.length-1], 2)
       // Listens constantly for the reset button click, and aborts the function if it occurs
       if (this.abort) {
         this.removeAllPaths();  // Repeated removeAllPaths in case of asynchronous call

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -300,6 +300,7 @@ export class TopbarComponent implements OnInit, DoCheck {
     if (!this.abort) {
       // Set all lines to opaque
       this.startText = "Finished!"             // Display that the algorithm has finished
+      this.algorithmFinished();
     } else {
       this.abort = false;                      // Setting abort back to false if aborted
     }
@@ -550,15 +551,22 @@ export class TopbarComponent implements OnInit, DoCheck {
   // Opens the snackbar warning of no algorithm selected
   noAlgorithmSelected():void {
     this._snackBar.open("Please select an algorithm!", "Close", {
-      duration: 5000,
+      duration: 3000
     });
   }
 
   // Opens a snackbar warning user that not enough nodes were selected
   notEnoughNodesSelected():void {
     this._snackBar.open("You must initialise at least 3 vertices!", "Close", {
-      duration: 5000
-    })
+      duration: 3000
+    });
+  }
+
+  // Opens a snackbar informing the user that the algorithm has finished!
+  algorithmFinished():void{
+    this._snackBar.open("Algorithm finished!", "Close", {
+      duration: 3000
+    });
   }
 
 }

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -274,29 +274,27 @@ export class TopbarComponent implements OnInit, DoCheck {
         break
     }
 
-    // ==========================================================================================
-    // =================================== SETTING PATH TYPES ===================================
+    // =================================================================================================================
+    // Setting Path Types
+
     // NOTE - MUST USE await this.sleep(1) ~~~ OTHERWISE paths can't keep up with the changes - which was why it didn't work yesterday
 
-    // METHOD 1 - SETTING THE TYPE OF EVERY PATH INDIVIDUALLY (fine for setting several paths)
+    // Setting a single path type:
     // NOTE - 1ms seems to work fine and not cause errors + doesn't cause noticeable delay
-
     // for(let p = 0; p < this.data.currPaths.length; p++){
     //   await this.sleep(1);
     //   this.data.setIndividualPathType(this.data.currPaths[p], 1);
     // }
 
-    // METHOD 2 - SETTING THE TYPE OF ALL EXISTING PATHS
+    // Setting type of all existing paths
     // CAUTION - sets all EXISTING paths to this type ~ HOWEVER: future paths will be created with the default type-0 (open to discussion ~ is this wanted behaviour?)
     // WHEN SETTING TYPES, all paths only detect CHANGES in the allPathType
     // SO if you want to set all paths to type-1 again, need an update with another data.setAllExistingPathsType(1)
 
     await this.sleep(1);
     this.data.setAllExistingPathsType(1);
-    // =================================== SETTING PATH TYPES ===================================
-    // ==========================================================================================
+    // =================================================================================================================
 
-    // TODO: Make paths opaque and other cleanup
     clearInterval(this.timeRef)                // Pause the timer when done
     this.timerRunning = false;                 // Stop "timerRunning"
     if (!this.abort) {
@@ -464,9 +462,14 @@ export class TopbarComponent implements OnInit, DoCheck {
       console.log(this.selectedPoints[previousIndex])
       console.log(this.selectedPoints[currentIndex])
       await this.sleep(this.runSpeed);  // Making use of async-await
-      // Create the path
+      // Change previous path colour to grey
+      if (this.data.currPaths.length != 0) {
+        this.data.setIndividualPathType(this.data.currPaths[this.data.currPaths.length-1], 0)
+      }
+      // Create the path as yellow
       this.createPath({A:{x:this.selectedPoints[previousIndex].x, y:this.selectedPoints[previousIndex].y},
                        B:{x:this.selectedPoints[currentIndex].x,  y:this.selectedPoints[currentIndex].y}});
+      this.data.setIndividualPathType(this.data.currPaths[this.data.currPaths.length-1], 2)
       // Listens constantly for the reset button click, and aborts the function if it occurs
       if (this.abort) {
         this.removeAllPaths();  // Repeated removeAllPaths in case of asynchronous call


### PR DESCRIPTION
Features implemented this pull request

- Added path colour changing for nearest neighbour
- Changed default path colour to yellow, type 2 (you can save some lines of code in your algorithms now, since all paths would be created initially as yellow before they should turn grey)
- Added convex hull to the algorithm list
- Implemented fully functional nearest insertion algorithm 
- Added snackbar popup when algorithm finishes

Important thoughts/notes
- I found that I actually didn't need await sleep(1) to get my paths to draw with the correct colour. Maybe try refactoring the code with the new default yellow colour and it'll help? Not a big deal as long as it works, but it's really good to have the default as yellow because otherwise the path can flash grey for 1 frame before being set to yellow.
- Your depth first search is doing many repeat distance calculations! I made the same mistake and had to start over because I realised you can generate an n x n matrix with the distances between all combinations of points and just access the distances that way. That way, you'll never have to calculate the same distance twice, it's all in a table for constant time lookup. Don't change it now since it works, knowing/learning about it is the most important. For future algorithms you can make use of my calculateDistanceMatrix helper function. Notice how the matrix is symmetric, but some extensions of the TSP will have it asymmetric, so going one way is a different distance from going the other between 2 cities.
- I still have the same issue with the abort, and quickly start causing the app to break. It's a relatively small issue, let's focus on finishing up these algorithms
- I made a helper method for calculating the length of any path where you can just pass in a path. Use it (calculatePathLength()) if you think it's useful.